### PR TITLE
Update vignette title in Vignettes %\VignetteIndexEntry

### DIFF
--- a/Package/vignettes/introduction_to_gpls.Rmd
+++ b/Package/vignettes/introduction_to_gpls.Rmd
@@ -4,7 +4,7 @@ author: "Derek Beaton"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{"Introduction to GPLS"}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Vignettes cannot be installed because all the %\VignetteIndexEntry items still say Vignette Title